### PR TITLE
Add CI/CD pipeline with GitHub Container Registry

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "schedule": ["before 6am on monday"],
+  "automerge": true,
+  "automergeType": "pr",
+  "platformAutomerge": true,
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "matchManagers": ["docker"],
+      "matchPackageNames": ["openjdk"],
+      "automerge": false,
+      "reviewersFromCodeOwners": true
+    }
+  ],
+  "labels": ["dependencies"]
+}

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,0 +1,52 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Log in to Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=raw,value=latest,enable={{is_default_branch}}
+          type=raw,value=1.1,enable={{is_default_branch}}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ The VNS (Visual Navigation System) plugin for ATAK requires specific GraphHopper
 
 ### Prerequisites
 - **Docker** installed and running on your system ([Download Docker](https://www.docker.com/get-started))
+- **Internet connection** for downloading maps and Docker images
 
 ### Usage
+> **✨ Zero setup required!** The script automatically downloads a pre-built Docker image on first run.
 1. Clone or download this repository
 2. Open a terminal in the project directory
 3. Make scripts executable (macOS/Linux only):
@@ -60,6 +62,18 @@ The VNS (Visual Navigation System) plugin for ATAK requires specific GraphHopper
 | Medium | Great Britain | ~5-8 minutes | 381 MB |
 | Large | Germany | ~10+ minutes | 760 MB |
 | Large | Ukraine | ~10+ minutes | 232 MB |
+
+## 🐳 Docker Image Options
+
+**Default (Recommended)**: Uses pre-built images from GitHub Container Registry
+- ✅ **Faster startup** - No build time required  
+- ✅ **Always up-to-date** - Automatically pulls versioned images (v1.1)
+- ✅ **No dependencies** - No need for build tools locally
+
+**Local Build**: Force local Docker build if needed
+```bash
+USE_PREBUILT=false ./run.sh great-britain
+```
 
 ## 📱 Installing on Your Android Device
 


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for automated Docker builds and publishing
- Use pre-built images from GitHub Container Registry by default
- Implement proper semantic versioning (v1.1)
- Add Renovate for dependency management
- Zero setup experience for users

## Key Features
- **Faster startup**: Pre-built images, no build time required
- **Automatic updates**: CI/CD publishes on every main branch push
- **Fallback support**: Local builds still work if registry fails
- **Dependency management**: Renovate keeps everything updated

## Testing
- [x] GitHub Actions workflow runs on PR
- [x] Docker image builds successfully
- [ ] Image gets published to ghcr.io (on merge)
- [ ] run.sh works with both pre-built and local images