### PR TITLE
fix(fetch): surface real fetch errors + IPv4 fallback (#26)

### DIFF
--- a/generate-data.sh
+++ b/generate-data.sh
@@ -146,11 +146,19 @@ GRAPH_FOLDER="${REGION_NAME}"
 # --- Fetch URLs from Geofabrik API ---
 echo "Fetching region URLs from Geofabrik API..."
 
+GEOFABRIK_INDEX_URL="https://download.geofabrik.de/index-v1-nogeom.json"
 retry_count=0
 max_retries=10
+WGET_ERR=$(mktemp)
 
 while [ $retry_count -lt $max_retries ]; do
-    if API_RESPONSE=$(wget -qO- "https://download.geofabrik.de/index-v1-nogeom.json" 2>/dev/null) && [ -n "$API_RESPONSE" ]; then
+    # Try a normal (dual-stack) request first; on failure, retry forcing IPv4
+    # (-4) for hosts/containers where IPv6 is present but broken. Real errors
+    # are captured to $WGET_ERR so we can surface them if all attempts fail.
+    if API_RESPONSE=$(wget -qO- "$GEOFABRIK_INDEX_URL" 2>>"$WGET_ERR") && [ -n "$API_RESPONSE" ]; then
+        break
+    fi
+    if API_RESPONSE=$(wget -4 -qO- "$GEOFABRIK_INDEX_URL" 2>>"$WGET_ERR") && [ -n "$API_RESPONSE" ]; then
         break
     fi
     retry_count=$((retry_count + 1))
@@ -160,8 +168,25 @@ done
 
 if [ $retry_count -eq $max_retries ]; then
     echo "❌ Error: Failed to fetch region data from Geofabrik API after $max_retries attempts"
+    echo ""
+    echo "----- Actual error reported by wget -----"
+    tail -n 8 "$WGET_ERR" 2>/dev/null | grep -v '^$' | tail -n 5 || echo "(no error output captured)"
+    echo "-----------------------------------------"
+    echo ""
+    echo "🔍 Quick diagnostics (run on the HOST, outside Docker):"
+    printf "   • DNS for download.geofabrik.de: "
+    if getent hosts download.geofabrik.de >/dev/null 2>&1; then echo "resolves OK inside container"; else echo "RESOLUTION FAILED inside container"; fi
+    echo "   • For the full handshake, run on the host:"
+    echo "       curl -v https://download.geofabrik.de/index-v1-nogeom.json"
+    echo ""
+    echo "   Common causes when a browser works but this does not:"
+    echo "     - a TLS-intercepting proxy/AV whose CA wget/curl does not trust"
+    echo "     - Docker's DNS cannot reach Geofabrik (check the host resolver)"
+    echo "     - broken IPv6, or an IP/geo block on Geofabrik's side"
+    rm -f "$WGET_ERR"
     exit 1
 fi
+rm -f "$WGET_ERR"
 
 # Extract URLs for the specified region using jq
 REGION_DATA=$(echo "$API_RESPONSE" | jq -r --arg region_id "$REGION_ID" '

--- a/list-regions.sh
+++ b/list-regions.sh
@@ -47,21 +47,45 @@ main() {
     local json_data
     local retry_count=0
     local max_retries=10
-    
+    local err_file
+    err_file=$(mktemp)
+
     while [ $retry_count -lt $max_retries ]; do
-        if json_data=$(curl -s "$INDEX_URL" 2>/dev/null) && [ -n "$json_data" ]; then
+        # Try a normal (dual-stack) request first; on failure, retry forcing
+        # IPv4 (-4) to work around hosts where IPv6 is configured but broken.
+        # Real errors are captured to $err_file so we can show them if we give up.
+        if json_data=$(curl -sS --fail --max-time 30 "$INDEX_URL" 2>>"$err_file") && [ -n "$json_data" ]; then
+            break
+        fi
+        if json_data=$(curl -4 -sS --fail --max-time 30 "$INDEX_URL" 2>>"$err_file") && [ -n "$json_data" ]; then
             break
         fi
         retry_count=$((retry_count + 1))
         echo "⚠️  Retry $retry_count/$max_retries - Failed to fetch region data from Geofabrik API"
         sleep 2
     done
-    
+
     if [ $retry_count -eq $max_retries ]; then
         echo "❌ Error: Failed to fetch region data from Geofabrik API after $max_retries attempts"
-        echo "Please check your internet connection and try again."
+        echo ""
+        echo "----- Actual error reported by curl -----"
+        tail -n 5 "$err_file" 2>/dev/null | sort -u || echo "(no error output captured)"
+        echo "-----------------------------------------"
+        echo ""
+        echo "🔍 Quick diagnostics:"
+        printf "   • DNS for download.geofabrik.de: "
+        if getent hosts download.geofabrik.de >/dev/null 2>&1; then echo "resolves OK"; else echo "RESOLUTION FAILED"; fi
+        echo "   • For the full handshake, run:"
+        echo "       curl -v https://download.geofabrik.de/index-v1-nogeom.json"
+        echo ""
+        echo "   Common causes when a browser works but this does not:"
+        echo "     - a TLS-intercepting proxy/AV whose CA curl does not trust"
+        echo "     - a DNS resolver that cannot reach Geofabrik"
+        echo "     - broken IPv6, or an IP/geo block on Geofabrik's side"
+        rm -f "$err_file"
         exit 1
     fi
+    rm -f "$err_file"
     
     local total_count
     total_count=$(echo "$json_data" | jq '.features | length')


### PR DESCRIPTION
## What

Both `list-regions.sh` (host, curl) and `generate-data.sh` (container, wget) suppressed the downloader's stderr with `2>/dev/null` (plus `-q`/`-s`). When a Geofabrik fetch fails, the user got only:

```
❌ Error: Failed to fetch region data from Geofabrik API after 10 attempts
```

…with no indication of *why* — making issues like #26 impossible to diagnose remotely.

## Why this isn't a fetch-URL bug

The endpoint and both code paths work fine from a clean environment:

| Path | Tool | Result |
|---|---|---|
| `./list-regions.sh` | `curl -s` | HTTP 200, 513 KB |
| `./run.sh` → container → `generate-data.sh` | `wget -qO-` | downloaded, exit 0 |

The reporter hit it via **two different tools in two different network namespaces**, both failing while their browser worked — which points to a network-layer issue on their side (TLS-intercepting proxy whose CA curl/wget don't trust, a DNS resolver that can't reach Geofabrik, broken IPv6, or a geo/IP block). The scripts simply couldn't report which.

## Changes

- Capture curl/wget stderr and **print the real error** on final failure
- Add an **IPv4-forced retry** (`curl -4` / `wget -4`) — mitigates broken-IPv6 hosts automatically
- Print a **DNS check** and the discriminating `curl -v` command that names the failing layer

Example output on a forced failure:
```
----- Actual error reported by curl -----
curl: (7) Failed to connect to 127.0.0.1 port 1 after 0 ms: Couldn't connect to server
-----------------------------------------
🔍 Quick diagnostics:
   • DNS for download.geofabrik.de: resolves OK
   • For the full handshake, run:
       curl -v https://download.geofabrik.de/index-v1-nogeom.json
```

## Testing

- `bash -n` + `shellcheck -S error` clean on both scripts
- Happy path: `list-regions.sh` still lists all 555 regions
- Failure path: diagnostics block verified (output above)

Refs #26