### PR TITLE
fix(fetch): make failure diagnostics actually print (follow-up to #28)

### DIFF
--- a/generate-data.sh
+++ b/generate-data.sh
@@ -149,16 +149,37 @@ echo "Fetching region URLs from Geofabrik API..."
 GEOFABRIK_INDEX_URL="https://download.geofabrik.de/index-v1-nogeom.json"
 retry_count=0
 max_retries=10
-WGET_ERR=$(mktemp)
+if ! WGET_ERR=$(mktemp 2>/dev/null) || [ -z "$WGET_ERR" ]; then
+    WGET_ERR="/tmp/vns-wget-err.$$"
+    : > "$WGET_ERR" 2>/dev/null || WGET_ERR="/dev/null"
+fi
+# Remove the temp file on any exit (including Ctrl-C), not just the happy path.
+[ "$WGET_ERR" != "/dev/null" ] && trap 'rm -f "$WGET_ERR"' EXIT
+
+# Portable DNS resolution check; getent may be absent from minimal images.
+dns_check_host() {
+    local host="$1"
+    if command -v getent >/dev/null 2>&1; then
+        getent hosts "$host" >/dev/null 2>&1 && { echo "resolves OK"; return; }
+        echo "RESOLUTION FAILED"; return
+    elif command -v nslookup >/dev/null 2>&1; then
+        nslookup "$host" >/dev/null 2>&1 && { echo "resolves OK"; return; }
+        echo "RESOLUTION FAILED"; return
+    fi
+    echo "could not check (no getent/nslookup available)"
+}
 
 while [ $retry_count -lt $max_retries ]; do
     # Try a normal (dual-stack) request first; on failure, retry forcing IPv4
     # (-4) for hosts/containers where IPv6 is present but broken. Real errors
     # are captured to $WGET_ERR so we can surface them if all attempts fail.
-    if API_RESPONSE=$(wget -qO- "$GEOFABRIK_INDEX_URL" 2>>"$WGET_ERR") && [ -n "$API_RESPONSE" ]; then
+    # NOTE: use -nv (not -q): -q silences the very stderr we need to capture.
+    # --tries=1 --timeout=30 makes each attempt fail fast instead of letting
+    # wget burn its own internal retries (which made the loop appear to hang).
+    if API_RESPONSE=$(wget -nv --tries=1 --timeout=30 -O- "$GEOFABRIK_INDEX_URL" 2>>"$WGET_ERR") && [ -n "$API_RESPONSE" ]; then
         break
     fi
-    if API_RESPONSE=$(wget -4 -qO- "$GEOFABRIK_INDEX_URL" 2>>"$WGET_ERR") && [ -n "$API_RESPONSE" ]; then
+    if API_RESPONSE=$(wget -4 -nv --tries=1 --timeout=30 -O- "$GEOFABRIK_INDEX_URL" 2>>"$WGET_ERR") && [ -n "$API_RESPONSE" ]; then
         break
     fi
     retry_count=$((retry_count + 1))
@@ -170,23 +191,25 @@ if [ $retry_count -eq $max_retries ]; then
     echo "❌ Error: Failed to fetch region data from Geofabrik API after $max_retries attempts"
     echo ""
     echo "----- Actual error reported by wget -----"
-    tail -n 8 "$WGET_ERR" 2>/dev/null | grep -v '^$' | tail -n 5 || echo "(no error output captured)"
+    if [ -s "$WGET_ERR" ]; then
+        tail -n 5 "$WGET_ERR"
+    else
+        echo "(no error output captured)"
+    fi
     echo "-----------------------------------------"
     echo ""
-    echo "🔍 Quick diagnostics (run on the HOST, outside Docker):"
-    printf "   • DNS for download.geofabrik.de: "
-    if getent hosts download.geofabrik.de >/dev/null 2>&1; then echo "resolves OK inside container"; else echo "RESOLUTION FAILED inside container"; fi
-    echo "   • For the full handshake, run on the host:"
+    echo "🔍 Diagnostics:"
+    printf "   • DNS for download.geofabrik.de (from inside this container): "
+    dns_check_host download.geofabrik.de
+    echo "   • To test from your HOST (outside Docker), run:"
     echo "       curl -v https://download.geofabrik.de/index-v1-nogeom.json"
     echo ""
     echo "   Common causes when a browser works but this does not:"
-    echo "     - a TLS-intercepting proxy/AV whose CA wget/curl does not trust"
+    echo "     - a TLS-intercepting proxy/AV whose CA wget does not trust"
     echo "     - Docker's DNS cannot reach Geofabrik (check the host resolver)"
     echo "     - broken IPv6, or an IP/geo block on Geofabrik's side"
-    rm -f "$WGET_ERR"
     exit 1
 fi
-rm -f "$WGET_ERR"
 
 # Extract URLs for the specified region using jq
 REGION_DATA=$(echo "$API_RESPONSE" | jq -r --arg region_id "$REGION_ID" '

--- a/list-regions.sh
+++ b/list-regions.sh
@@ -35,6 +35,27 @@ format_output() {
     done
 }
 
+# Portable DNS resolution check. getent is Linux-only (absent on macOS and some
+# minimal images), so fall back through host/nslookup/python3 before giving up.
+dns_check_host() {
+    local host="$1"
+    if command -v getent >/dev/null 2>&1; then
+        getent hosts "$host" >/dev/null 2>&1 && { echo "resolves OK"; return; }
+        echo "RESOLUTION FAILED"; return
+    elif command -v host >/dev/null 2>&1; then
+        host "$host" >/dev/null 2>&1 && { echo "resolves OK"; return; }
+        echo "RESOLUTION FAILED"; return
+    elif command -v nslookup >/dev/null 2>&1; then
+        nslookup "$host" >/dev/null 2>&1 && { echo "resolves OK"; return; }
+        echo "RESOLUTION FAILED"; return
+    elif command -v python3 >/dev/null 2>&1; then
+        python3 -c "import socket,sys; socket.gethostbyname(sys.argv[1])" "$host" >/dev/null 2>&1 \
+            && { echo "resolves OK"; return; }
+        echo "RESOLUTION FAILED"; return
+    fi
+    echo "could not check (no getent/host/nslookup/python3 available)"
+}
+
 # Main function
 main() {
     check_jq
@@ -47,8 +68,15 @@ main() {
     local json_data
     local retry_count=0
     local max_retries=10
-    local err_file
-    err_file=$(mktemp)
+    # NOTE: err_file is intentionally NOT 'local' — the EXIT trap below fires
+    # after main() returns, by which point a local would be out of scope and
+    # the temp file would leak on every successful run.
+    if ! err_file=$(mktemp 2>/dev/null) || [ -z "$err_file" ]; then
+        err_file="/tmp/vns-fetch-err.$$"
+        : > "$err_file" 2>/dev/null || err_file="/dev/null"
+    fi
+    # Clean the temp file up even if the user hits Ctrl-C mid-fetch.
+    [ "$err_file" != "/dev/null" ] && trap 'rm -f "$err_file"' EXIT
 
     while [ $retry_count -lt $max_retries ]; do
         # Try a normal (dual-stack) request first; on failure, retry forcing
@@ -69,12 +97,16 @@ main() {
         echo "❌ Error: Failed to fetch region data from Geofabrik API after $max_retries attempts"
         echo ""
         echo "----- Actual error reported by curl -----"
-        tail -n 5 "$err_file" 2>/dev/null | sort -u || echo "(no error output captured)"
+        if [ -s "$err_file" ]; then
+            tail -n 5 "$err_file"
+        else
+            echo "(no error output captured)"
+        fi
         echo "-----------------------------------------"
         echo ""
         echo "🔍 Quick diagnostics:"
         printf "   • DNS for download.geofabrik.de: "
-        if getent hosts download.geofabrik.de >/dev/null 2>&1; then echo "resolves OK"; else echo "RESOLUTION FAILED"; fi
+        dns_check_host download.geofabrik.de
         echo "   • For the full handshake, run:"
         echo "       curl -v https://download.geofabrik.de/index-v1-nogeom.json"
         echo ""
@@ -82,10 +114,8 @@ main() {
         echo "     - a TLS-intercepting proxy/AV whose CA curl does not trust"
         echo "     - a DNS resolver that cannot reach Geofabrik"
         echo "     - broken IPv6, or an IP/geo block on Geofabrik's side"
-        rm -f "$err_file"
         exit 1
     fi
-    rm -f "$err_file"
     
     local total_count
     total_count=$(echo "$json_data" | jq '.features | length')


### PR DESCRIPTION
Follow-up hotfix addressing the automated review feedback on #28 (Copilot + Codex). Several of those bugs **defeated the diagnostics #28 was meant to add**.

## Bugs fixed

| # | Bug | Fix |
|---|-----|-----|
| 1 | **`wget -q` suppressed the captured stderr** → container path printed a *blank* "Actual error" block on failure (the whole point of #28). curl path was unaffected. | `wget -nv` |
| 2 | `wget` could burn its own internal retries → outer loop appears to hang | `--tries=1 --timeout=30` |
| 3 | `... \| tail \| sort -u \|\| echo "(no error...)"` fallback **never fired** (pipeline status is `tail`'s, always 0) | explicit `[ -s ]` test |
| 4 | `sort -u` reordered/obscured the curl error lines | show as logged |
| 5 | bare `getent` DNS check is **absent on macOS / minimal images** → false "RESOLUTION FAILED" | portable `getent→host→nslookup→python3` probe |
| 6 | `mktemp` failure unchecked; temp file leaked on Ctrl-C | check + fallback + `trap ... EXIT` |
| 7 | `list-regions.sh` leaked a temp file **per successful run** (`local err_file` out of scope when EXIT trap fires) | make it global |
| 8 | contradictory "run on HOST" / "inside container" wording | corrected |

## Verification (behavioral, not just lint)

- **Container path** (the #1 bug): built/ran in Docker with the network isolated — failure now prints the real `wget: unable to resolve host address …` instead of a blank block.
- **Host path**: `list-regions.sh` output **byte-identical** to pre-change baseline; forced-failure path prints the real `curl` error.
- **Leak**: confirmed 2 successful runs leaked 2 temp files before; **0** after the fix.
- `bash -n` + `shellcheck -S error` clean on both scripts.

Refs #26, #28